### PR TITLE
Allow use as a library

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,6 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :main clj-livereload.core
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [cheshire "5.4.0"]
                  [ring "1.3.1"]

--- a/src/clj_livereload/core.clj
+++ b/src/clj_livereload/core.clj
@@ -54,7 +54,7 @@
                       (send! channel (json/generate-string (hello-message)))))))))
 
 (defn- send-livereload-js [req]
-  (-> (response (slurp "resources/livereload.js"))
+  (-> (resource-response "livereload.js")
       (content-type "application/javascript")))
 
 (defroutes routes


### PR DESCRIPTION
Minimal fixes make this work as a library. Slurp doesn't work when the file doesn't exists in file system, resource-response should be used instead of load the file from classpath.

I'm using the library with https://github.com/Deraen/boot-livereload.
