### PR TITLE
Update ring and drop compojure dependency for core

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,12 +5,12 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [cheshire "5.4.0"]
-                 [ring "1.3.1"]
-                 [compojure "1.2.1"]
+                 [ring "1.4.0"]
                  [http-kit "2.1.19"]
                  [hawk "0.2.4"]
                  [org.webjars.npm/livereload-js "2.2.2"]]
   :profiles {:example {:resource-paths ["example-resources"]
                        :source-paths ["example"]
+                       :dependencies [[compojure "1.4.0"]]
                        :main clj-livereload.test}}
   :aliases {"start-example" ["with-profile" "example" "run"]})

--- a/src/clj_livereload/core.clj
+++ b/src/clj_livereload/core.clj
@@ -1,6 +1,5 @@
 (ns clj-livereload.core
-  (:require [compojure.core :refer [routes GET]]
-            [org.httpkit.server :refer [run-server with-channel on-close on-receive send! open?]]
+  (:require [org.httpkit.server :refer [run-server with-channel on-close on-receive send! open?]]
             [ring.middleware.reload :refer :all]
             [ring.util.response :refer :all]
             [cheshire.core :as json]
@@ -55,12 +54,15 @@
         (swap! state update-in [:reload-channels] disj channel)))))
 
 (defn- handler [state]
-  (routes
-    (GET "/livereload.js" req
-      (-> (resource-response "META-INF/resources/webjars/livereload-js/2.2.2/dist/livereload.js" {:root ""})
-          (content-type "application/javascript")))
-    (GET "/livereload" req
-      (handle-livereload state req))))
+  (fn [req]
+    (if (= :get (:request-method req))
+      (case (:uri req)
+        "/livereload.js"
+        (-> (resource-response "META-INF/resources/webjars/livereload-js/2.2.2/dist/livereload.js" {:root ""})
+            (content-type "application/javascript"))
+        "/livereload"
+        (handle-livereload state req)
+        nil))))
 
 (defn create-state
   "Creates the state holding open websocket connections."


### PR DESCRIPTION
This updates ring and compojure dependencies.

Old compojure doesn't work with Clojure 1.7. This also remove Compojure dependency from the library as it's easy enough to implement routing for two requests manually. Compojure is still used for the example.
