### PR TITLE
Update http-kit to make it compatible with java 11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [cheshire "5.4.0"]
                  [ring "1.3.1"]
                  [compojure "1.2.1"]
-                 [http-kit "2.1.19"]
+                 [http-kit "2.5.0"]
                  [hawk "0.2.4"]
                  [org.webjars.npm/livereload-js "2.2.2"]]
   :profiles {:example {:resource-paths ["example-resources"]


### PR DESCRIPTION

This is what I got in a project, using java 11:
```
:clojure.main/message
 "Syntax error (ClassNotFoundException) compiling at (org/httpkit/server.clj:1:1).\njavax.xml.bind.DatatypeConverter\n",
 :clojure.main/triage
 {:clojure.error/phase :compile-syntax-check,
  :clojure.error/line 1,
  :clojure.error/column 1,
  :clojure.error/source "server.clj",
  :clojure.error/path "org/httpkit/server.clj",
  :clojure.error/class java.lang.ClassNotFoundException,
  :clojure.error/cause "javax.xml.bind.DatatypeConverter"},
 :clojure.main/trace
 {:via
  [{:type clojure.lang.Compiler$CompilerException,
    :message "Syntax error compiling at (org/httpkit/server.clj:1:1).",
    :data
    {:clojure.error/phase :compile-syntax-check,
     :clojure.error/line 1,
     :clojure.error/column 1,
     :clojure.error/source "org/httpkit/server.clj"},
    :at [clojure.lang.Compiler load "Compiler.java" 76
```